### PR TITLE
12 prepare package json to publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,4 @@
 
 This plugin supports teams to smoothly convert their existing production JavaScript code to move forward and use TypeScript.
 
-
-[ESLint Working with Rules](https://github.com/unicop/eslint-plugin-migrate-to-typescript)
+[ESLint Working with Rules](https://github.com/postman-as-code/eslint-plugin-migrate-to-typescript)

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "eslint-plugin-migrate-to-ts",
+  "name": "eslint-plugin-migrate-to-typescript",
   "version": "1.0.0",
   "license": "MIT",
   "description": "Opinionated ESLint plugin that makes migration to TypeScript super-easy and user-friendly.",
@@ -7,10 +7,10 @@
   "types": "build/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unicop/eslint-plugin-migrate-to-typescript.git"
+    "url": "https://github.com/postman-as-code/eslint-plugin-migrate-to-typescript.git"
   },
   "bugs": {
-    "url": "https://github.com/unicop/eslint-plugin-migrate-to-typescript/issues"
+    "url": "https://github.com/postman-as-code/eslint-plugin-migrate-to-typescript/issues"
   },
   "contributors": [
     "unicop <its.op.the.unicorn@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,39 +1,52 @@
 {
-  "name": "eslint-plugin-mig2ts",
+  "name": "eslint-plugin-migrate-to-ts",
   "version": "1.0.0",
-  "description": "",
+  "license": "MIT",
+  "description": "Opinionated ESLint plugin that makes migration to TypeScript super-easy.",
   "main": "build/index.js",
+  "types": "build/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/unicop/eslint-plugin-migrate-to-typescript.git"
+  },
+  "bugs": {
+    "url": "https://github.com/unicop/eslint-plugin-migrate-to-typescript/issues"
+  },
+  "contributors": [
+    "unicop <its.op.the.unicorn@gmail.com>",
+    "neriyarden"
+  ],
+  "keywords": ["eslint", "typescript", "@typescript-eslint/eslint-plugin", "migrate", "@typescript-eslint/parser"],
   "scripts": {
-    "prebuild": "rimraf build",
     "build": "tsc -p tsconfig.build1.json",
     "test": "jest",
-    "test:coverage": "jest --coverage --silent"
+    "prebuild": "rimraf build && lint",
+    "test:coverage": "jest --coverage --silent",
+    "lint": "eslint . --ext .ts"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "workspaces": {
-    "packages": [
-      "packages/*"
-    ]
-  },
-  "peerDependencies": {
-    "@typescript-eslint/parser": "^5.0.0",
-    "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+  "engines": {
+    "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
   },
   "dependencies": {
     "@typescript-eslint/types": "^5.23.0",
     "@typescript-eslint/utils": "^5.23.0"
   },
+  "peerDependencies": {
+    "@typescript-eslint/parser": "^5.0.0",
+    "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  },
   "devDependencies": {
-    "@babel/types": "^7.17.12",
     "@types/jest": "^27.5.1",
     "@types/semver": "^7.3.9",
     "@typescript-eslint/parser": "^5.25.0",
     "babel-eslint": "^10.1.0",
-    "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8",
+    "eslint": "^6 || ^7.2.0 || ^8",
     "jest": "^28.1.0",
-    "semver": "^7.3.7",
     "ts-jest": "^28.0.2",
     "ts-node": "^10.7.0",
     "typescript": "^4.6.4"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "eslint-plugin-migrate-to-ts",
   "version": "1.0.0",
   "license": "MIT",
-  "description": "Opinionated ESLint plugin that makes migration to TypeScript super-easy.",
+  "description": "Opinionated ESLint plugin that makes migration to TypeScript super-easy and user-friendly.",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": {

--- a/src/rules/no-dynamic-import.ts
+++ b/src/rules/no-dynamic-import.ts
@@ -1,5 +1,5 @@
 import { TSESTree, AST_NODE_TYPES } from '@typescript-eslint/types';
-import { BABEL_PARSER_AST_NODE_TYPES, TBABEL_PARSER_AST_NODE_TYPES } from '../types/babel-ast-nodes';
+
 import { createRule } from '../util';
 
 export type Options = [{ esmodule?: boolean }];
@@ -18,7 +18,7 @@ function isDynamicImport(node: TSESTree.CallExpression) {
     return node &&
         node.callee &&
         // from @babel/parser
-        node.callee.type === BABEL_PARSER_AST_NODE_TYPES.Import as string
+        node.callee.type === "Import" as any
 }
 
 function isStaticValue(arg: TSESTree.CallExpressionArgument | TSESTree.Expression) {

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,6 +1,6 @@
 import { ESLintUtils } from "@typescript-eslint/utils";
 export { ruleMessageTemplate } from './rule-msg-template'
-const repoUrl = 'https://github.com/unicop/eslint-plugin-migrate-to-typescript'
+const repoUrl = 'https://github.com/postman-as-code/eslint-plugin-migrate-to-typescript'
 export const createRule = ESLintUtils.RuleCreator(
     (name) => `${repoUrl}/blob/master/docs/rules/${name}.md`
 );


### PR DESCRIPTION
## Motivation

According to the standards, `package-json` should be set up appropriately before publishing into the public registry to make sure other developers can easily read/use/debug/contribute/fork it.
I took most of the fields from the `@typescript-eslint/eslint-plugin`.

### Key notes

- I followed peer deps, engines and so on according to `@typescript-eslint` requirements, because we focus on migration to typescript, we can rely our clients compatible with their requirements.
- We need to create docs to our existing rules
- we should decide the final name of this package.