### PR TITLE
5-no-esm-export-default

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -155,7 +155,7 @@
             "allow": [
                 "**/src/rules/*.ts", 
                 "**/src/configs/*.ts",
-                "**/shared/types",
+                "**/shared/*",
                 "**/src/shared/types"
             ]
         }],

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -3,13 +3,15 @@ import noEsmDynamicImport from './no-esm-dynamic-import';
 import noRequire from './no-require';
 import noCommonjsExports from './no-commonjs-exports';
 import noCommonJsModuleExports from './no-commonjs-module-exports';
+import noEsmExportDefault from './no-esm-export-default';
 
 export const CRules = {
-    // commonjs modules
+    // commonjs
     'no-require': noRequire,
     'no-commonjs-dynamic-require': noCommonJsDynamicRequire,
     'no-commonjs-exports': noCommonjsExports,
     'no-commonjs-module-exports': noCommonJsModuleExports,
     // esm
+    'no-esm-export-default': noEsmExportDefault,
     'no-esm-dynamic-import': noEsmDynamicImport,
 };

--- a/src/rules/no-commonjs-exports.ts
+++ b/src/rules/no-commonjs-exports.ts
@@ -1,6 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/types';
 import { AST_NODE_TYPES } from '@typescript-eslint/types';
-import { CEScopeType } from '../constants';
+import { CEScopeType } from '../shared/constants';
 import type { TScope } from '../shared/types';
 import { createRule, ruleMessageTemplate } from '../util';
 

--- a/src/rules/no-esm-export-default.ts
+++ b/src/rules/no-esm-export-default.ts
@@ -1,0 +1,47 @@
+import { Scope } from '@typescript-eslint/utils/dist/ts-eslint';
+import { createRule, ruleMessageTemplate } from '../util';
+import { EScopeType } from "../constants";
+
+export type Options = [];
+export type MessageIds = 'noExportDefault';
+
+function isModuleScope(scope: Scope.Scope) {
+    return scope.variableScope.type === EScopeType.Module;
+}
+
+export default createRule<Options, MessageIds>({
+    defaultOptions: [],
+    name: 'no-dynamic-import',
+
+    meta: {
+        type: 'suggestion',
+        docs: {
+            description: 'Using this rule to disable the use of dynamic require for CommonJS or ESM import.',
+            recommended: false
+        },
+        messages: {
+            noExportDefault: ruleMessageTemplate({
+                linterMessage: 'using default export is not allowed',
+                why: 'ESM export default causing inconsistent naming and confusion when project still using both ESM and CommonJS.'
+            })
+        },
+        schema: [{}],
+    },
+
+    create(context) {
+
+        const [] = context.options;
+
+        return {
+            ExportDefaultDeclaration(node) {
+                if (isModuleScope(context.getScope())) {
+                    context.report({
+                        messageId: 'noExportDefault',
+                        node,
+                    })
+                }
+            },
+        };
+    },
+})
+

--- a/src/rules/no-esm-export-default.ts
+++ b/src/rules/no-esm-export-default.ts
@@ -1,47 +1,44 @@
-import { Scope } from '@typescript-eslint/utils/dist/ts-eslint';
 import { createRule, ruleMessageTemplate } from '../util';
-import { EScopeType } from "../constants";
+import type { TScope } from '../shared/types';
+import { CEScopeType } from '../shared/constants';
 
-export type Options = [];
-export type MessageIds = 'noExportDefault';
+export type TOptions = [];
+export type TMessageIds = 'noExportDefault';
 
-function isModuleScope(scope: Scope.Scope) {
-    return scope.variableScope.type === EScopeType.Module;
+function isModuleScope(scope: TScope.Scope) {
+    return scope.variableScope.type === CEScopeType.Module;
 }
 
-export default createRule<Options, MessageIds>({
+export default createRule<TOptions, TMessageIds>({
     defaultOptions: [],
-    name: 'no-dynamic-import',
+    name: 'no-esm-export-default',
 
     meta: {
         type: 'suggestion',
         docs: {
-            description: 'Using this rule to disable the use of dynamic require for CommonJS or ESM import.',
-            recommended: false
+            description:
+                'Using this rule to disable the use of dynamic require for CommonJS or ESM import.',
+            recommended: false,
         },
         messages: {
             noExportDefault: ruleMessageTemplate({
                 linterMessage: 'using default export is not allowed',
-                why: 'ESM export default causing inconsistent naming and confusion when project still using both ESM and CommonJS.'
-            })
+                why: 'ESM export default causing inconsistent naming and confusion when project still using both ESM and CommonJS.',
+            }),
         },
         schema: [{}],
     },
 
     create(context) {
-
-        const [] = context.options;
-
         return {
             ExportDefaultDeclaration(node) {
                 if (isModuleScope(context.getScope())) {
                     context.report({
                         messageId: 'noExportDefault',
                         node,
-                    })
+                    });
                 }
             },
         };
     },
-})
-
+});

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -2,7 +2,7 @@ import type {
     TCamelToKebabCase,
     TSnakeCaseToKebabCase,
     TScopeType,
-} from '../shared/types';
+} from '../types';
 
 type TFixedScopeType = {
     [key in Capitalize<TSnakeCaseToKebabCase<TScopeType>>]: TFixedKeys<key>;

--- a/tests/rules/no-esm-export-default.test.ts
+++ b/tests/rules/no-esm-export-default.test.ts
@@ -1,0 +1,48 @@
+import rule from '../../src/rules/no-esm-export-default';
+import { RuleTester } from '../RuleTester';
+
+const error = {
+    message: 'Calls to require() should use string literals',
+};
+
+const ruleTester = new RuleTester({
+    parser: '@typescript-eslint/parser',
+    parserOptions: {
+        sourceType: 'module'
+    }
+});
+
+ruleTester.run('no-esm-export-default', rule, {
+    valid: [
+        // ESM named export
+        { code: 'export const x = 1' },
+        { code: 'export const x = () => {}' },
+        { code: 'export { name }' },
+        { code: 'export function x() {}' },
+        { code: 'export enum x { X = 1 }' },
+        { code: 'export type x = { X: number }' },
+        { code: 'export interface x { X: number }' },
+        // TypeScript ESM syntax for CommonJS export
+        { code: 'export = { X: 1 }' },
+        // commonjs
+        { code: 'module.exports = { X: 1 }' },
+        { code: 'module.exports.a = { X: 1 }' },
+        { code: 'exports = { X: 1 }' },
+        { code: 'exports.a = { X: 1 }' },
+        // ignore when script
+        { 
+            code: "export default {}",
+            parserOptions: {
+                sourceType: 'script'
+            } 
+        }
+    ],
+    invalid: [
+        // esm export default
+       { code: 'export default {}', errors: [{messageId: 'noExportDefault'}] },
+       { code: 'export default someVar;', errors: [{messageId: 'noExportDefault'}] },
+       { code: 'export default "primitive"', errors: [{messageId: 'noExportDefault'}] },
+       { code: 'export default () => {}', errors: [{messageId: 'noExportDefault'}] }
+    ]
+});
+

--- a/tests/rules/no-esm-export-default.test.ts
+++ b/tests/rules/no-esm-export-default.test.ts
@@ -1,15 +1,11 @@
 import rule from '../../src/rules/no-esm-export-default';
-import { RuleTester } from '../RuleTester';
-
-const error = {
-    message: 'Calls to require() should use string literals',
-};
+import { RuleTester } from '../rule-tester';
 
 const ruleTester = new RuleTester({
     parser: '@typescript-eslint/parser',
     parserOptions: {
-        sourceType: 'module'
-    }
+        sourceType: 'module',
+    },
 });
 
 ruleTester.run('no-esm-export-default', rule, {
@@ -30,19 +26,30 @@ ruleTester.run('no-esm-export-default', rule, {
         { code: 'exports = { X: 1 }' },
         { code: 'exports.a = { X: 1 }' },
         // ignore when script
-        { 
-            code: "export default {}",
+        {
+            code: 'export default {}',
             parserOptions: {
-                sourceType: 'script'
-            } 
-        }
+                sourceType: 'script',
+            },
+        },
     ],
     invalid: [
         // esm export default
-       { code: 'export default {}', errors: [{messageId: 'noExportDefault'}] },
-       { code: 'export default someVar;', errors: [{messageId: 'noExportDefault'}] },
-       { code: 'export default "primitive"', errors: [{messageId: 'noExportDefault'}] },
-       { code: 'export default () => {}', errors: [{messageId: 'noExportDefault'}] }
-    ]
+        {
+            code: 'export default {}',
+            errors: [{ messageId: 'noExportDefault' }],
+        },
+        {
+            code: 'export default someVar;',
+            errors: [{ messageId: 'noExportDefault' }],
+        },
+        {
+            code: 'export default "primitive"',
+            errors: [{ messageId: 'noExportDefault' }],
+        },
+        {
+            code: 'export default () => {}',
+            errors: [{ messageId: 'noExportDefault' }],
+        },
+    ],
 });
-


### PR DESCRIPTION
# Motivation

- When migrating existing JS projects into TS, without refactoring all code to TS at once, `esm` `export default` causes inconsistency between CommonJS modules and ES Modules.
- Another thing is inconsistent naming between other modules that `import` the "default", because it is not named.